### PR TITLE
Bugfix de pauta e modifica lógica de filtragem

### DIFF
--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -40,6 +40,7 @@ def get_time_filtered_pauta(request):
     data_referencia = request.query_params.get('data_referencia')
 
     queryset = PautaHistorico.objects
+    date = None
 
     if data_referencia:
         try:
@@ -47,14 +48,17 @@ def get_time_filtered_pauta(request):
         except ValueError:
             print(
                 f'Data de referência ({data_referencia}) inválida. ')
+            date = datetime.datetime.now().strptime('%Y-%m-%d')
         else:
             queryset = queryset.filter(data__gte=date)
 
-    if(date.weekday() == 4):  # friday
-        end_date = date + timedelta(days=6)
-        queryset = queryset.filter(data__lte=end_date)
+        if(date.weekday() == 4):  # friday
+            end_date = date + timedelta(days=6)
+            queryset = queryset.filter(data__lte=end_date)
+        else:
+            queryset = queryset.filter(data__week=date.isocalendar()[1],
+                                       data__year=date.isocalendar()[0])
+    if not data_referencia:
+        return queryset.filter()
     else:
-        queryset = queryset.filter(data__week=date.isocalendar()[1],
-                                   data__year=date.isocalendar()[0])
-
-    return queryset
+        return queryset

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -32,29 +32,27 @@ def get_time_filtered_temperatura(request):
 
 
 def get_time_filtered_pauta(request):
+    '''
+    Filtra as pautas que ocorreram depois ou no dia da data_referencia. Se a data_referencia é uma sexta-feira, retornará
+    todas as pautas com um período de 6 dias após, se não, retorna as pautas da mesma semana da data_referencia.
+    '''
     data_referencia = request.query_params.get('data_referencia')
-    semanas_anteriores = request.query_params.get('semanas_anteriores')
 
     queryset = PautaHistorico.objects
 
-    date = None
     if data_referencia:
         try:
             date = datetime.strptime(data_referencia, '%Y-%m-%d')
         except ValueError:
             print(
-                f'Data de referência ({data_referencia}) inválida. '
-                'Utilizando data atual como data de referência.')
+                f'Data de referência ({data_referencia}) inválida. ')
         else:
-            queryset = queryset.filter(data__lte=date)
+            queryset = queryset.filter(data__gte=date)
 
-    if semanas_anteriores:
-        if not date:
-            date = datetime.today()
-        start_date = date - timedelta(weeks=int(semanas_anteriores))
-        queryset = queryset.filter(data__gte=start_date)
-
-    if not data_referencia and not semanas_anteriores:
-        return queryset.filter()
+    if(date.weekday() == 4): # friday
+        end_date = date + timedelta(days=6)
+        queryset = queryset.filter(data__lte=end_date)
     else:
-        return queryset
+        queryset = queryset.filter(data__week=date.isocalendar()[1], data__year=date.isocalendar()[0])
+
+    return queryset

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -42,8 +42,8 @@ def get_time_filtered_pauta(request):
     queryset = PautaHistorico.objects
 
     if not data_referencia:
-        return queryset.fitler()
-  
+        return queryset.filter()
+
     date = datetime.strptime(data_referencia, '%Y-%m-%d')
     queryset = queryset.filter(data__gte=date)
 
@@ -53,5 +53,5 @@ def get_time_filtered_pauta(request):
     else:
         queryset = queryset.filter(data__week=date.isocalendar()[1],
                                    data__year=date.isocalendar()[0])
-    
+
     return queryset

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -33,8 +33,9 @@ def get_time_filtered_temperatura(request):
 
 def get_time_filtered_pauta(request):
     '''
-    Filtra as pautas que ocorreram depois ou no dia da data_referencia. Se a data_referencia é uma sexta-feira, retornará
-    todas as pautas com um período de 6 dias após, se não, retorna as pautas da mesma semana da data_referencia.
+    Filtra as pautas que ocorreram depois ou no dia da data_referencia. Se a
+    data_referencia é uma sexta-feira, retornará todas as pautas com um
+    período de 6 dias após, se não,retorna as pautas da mesma semana da data_referencia.
     '''
     data_referencia = request.query_params.get('data_referencia')
 
@@ -49,10 +50,11 @@ def get_time_filtered_pauta(request):
         else:
             queryset = queryset.filter(data__gte=date)
 
-    if(date.weekday() == 4): # friday
+    if(date.weekday() == 4):  # friday
         end_date = date + timedelta(days=6)
         queryset = queryset.filter(data__lte=end_date)
     else:
-        queryset = queryset.filter(data__week=date.isocalendar()[1], data__year=date.isocalendar()[0])
+        queryset = queryset.filter(data__week=date.isocalendar()[1],
+                                   data__year=date.isocalendar()[0])
 
     return queryset

--- a/api/utils/filters.py
+++ b/api/utils/filters.py
@@ -40,25 +40,18 @@ def get_time_filtered_pauta(request):
     data_referencia = request.query_params.get('data_referencia')
 
     queryset = PautaHistorico.objects
-    date = None
 
-    if data_referencia:
-        try:
-            date = datetime.strptime(data_referencia, '%Y-%m-%d')
-        except ValueError:
-            print(
-                f'Data de referência ({data_referencia}) inválida. ')
-            date = datetime.datetime.now().strptime('%Y-%m-%d')
-        else:
-            queryset = queryset.filter(data__gte=date)
-
-        if(date.weekday() == 4):  # friday
-            end_date = date + timedelta(days=6)
-            queryset = queryset.filter(data__lte=end_date)
-        else:
-            queryset = queryset.filter(data__week=date.isocalendar()[1],
-                                       data__year=date.isocalendar()[0])
     if not data_referencia:
-        return queryset.filter()
+        return queryset.fitler()
+  
+    date = datetime.strptime(data_referencia, '%Y-%m-%d')
+    queryset = queryset.filter(data__gte=date)
+
+    if(date.weekday() == 4):  # friday
+        end_date = date + timedelta(days=6)
+        queryset = queryset.filter(data__lte=end_date)
     else:
-        return queryset
+        queryset = queryset.filter(data__week=date.isocalendar()[1],
+                                   data__year=date.isocalendar()[0])
+    
+    return queryset


### PR DESCRIPTION
Resolvi o bugfix de mostrar pautas antigas e adicionei a seguinte lógica de filtragem:

-  Se a data de referência for uma sexta-feira, irá mostrar as pautas da próxima semana
- Não retorna pautas que já aconteceram, exemplo, se a data de referência for uma quarta, não vai retornar da terça e segunda
-  Se não for sexta, retorna as pautas que acontecem naquela semana e que não seja passado